### PR TITLE
Google Pluginがバグっていたので修正した

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -224,7 +224,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
           };
           homeDispatch({
             field: 'selectedConversation',
-            value: updateConversation,
+            value: updatedConversation,
           });
           saveConversation(updatedConversation);
           const updatedConversations: Conversation[] = conversations.map(

--- a/pages/api/google.ts
+++ b/pages/api/google.ts
@@ -144,7 +144,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<any>) => {
     res.status(200).json({ answer });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Error' });
+    res.status(500).json({ error: String(error) });
   }
 };
 

--- a/pages/api/google.ts
+++ b/pages/api/google.ts
@@ -6,6 +6,7 @@ import { cleanSourceText } from '@/utils/server/google';
 import { Message } from '@/types/chat';
 import { GoogleBody, GoogleSource } from '@/types/google';
 
+import { Tiktoken, encoding_for_model } from '@dqbd/tiktoken';
 import { Readability } from '@mozilla/readability';
 import endent from 'endent';
 import jsdom, { JSDOM } from 'jsdom';
@@ -14,6 +15,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<any>) => {
   try {
     const { messages, key, model, googleAPIKey, googleCSEId } =
       req.body as GoogleBody;
+
+    const encoding = encoding_for_model(model.id);
 
     const userMessage = messages[messages.length - 1];
     const query = encodeURIComponent(userMessage.content.trim());
@@ -68,8 +71,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<any>) => {
 
             return {
               ...source,
-              // TODO: switch to tokens
-              text: sourceText.slice(0, 2000),
+              text: truncateTokens(encoding, sourceText, 1000),
             } as GoogleSource;
           }
           // }
@@ -145,5 +147,18 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<any>) => {
     res.status(500).json({ error: 'Error'})
   }
 };
+
+/**
+ * Truncates the input text to the specified tokens limit.
+ */
+function truncateTokens(encoding: Tiktoken, text: string, limit: number) {
+  const tokens = encoding.encode(text);
+  if (tokens.length <= limit) return text;
+  const truncatedTokens = tokens.slice(0, limit);
+  const truncatedText = new TextDecoder().decode(
+    encoding.decode(truncatedTokens),
+  );
+  return truncatedText;
+}
 
 export default handler;

--- a/pages/api/google.ts
+++ b/pages/api/google.ts
@@ -144,7 +144,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<any>) => {
     res.status(200).json({ answer });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Error'})
+    res.status(500).json({ error: 'Error' });
   }
 };
 

--- a/pages/api/google.ts
+++ b/pages/api/google.ts
@@ -6,7 +6,7 @@ import { cleanSourceText } from '@/utils/server/google';
 import { Message } from '@/types/chat';
 import { GoogleBody, GoogleSource } from '@/types/google';
 
-import { Tiktoken, encoding_for_model } from '@dqbd/tiktoken';
+import { Tiktoken, TiktokenModel, encoding_for_model } from '@dqbd/tiktoken';
 import { Readability } from '@mozilla/readability';
 import endent from 'endent';
 import jsdom, { JSDOM } from 'jsdom';
@@ -16,7 +16,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<any>) => {
     const { messages, key, model, googleAPIKey, googleCSEId } =
       req.body as GoogleBody;
 
-    const encoding = encoding_for_model(model.id);
+    const encoding = encoding_for_model(model.id as TiktokenModel);
 
     const userMessage = messages[messages.length - 1];
     const query = encodeURIComponent(userMessage.content.trim());


### PR DESCRIPTION
* フロントエンドのtypoを修正
* バックエンドでGoogleのCustom Search APIから取り出した結果をトークン上限に収める処理が `.slice(0, 2000)` になっていてマルチバイト文字では動作しなかったため、トークン数で切るようにした

# プラグインの使い方

雷マークをクリック→Google Searchを選ぶと、Google検索が有効になる

https://github.com/teramotodaiki/chatbot-ui/assets/6120593/b8d86ac7-eb7d-4cde-b5af-219809a836c7

動画ではカットしているが、実際かなり遅い。なぜかストリームが無効になっている（またベータ版だからだと思う）

# Future work

Custom Search APIの結果を取得する部分と、それをGPTに投げる部分は、別エンドポイントにした方がよいと思う。
前者はNode.js runtimeでもよく、後者はEdge runtimeでstream: trueにしたらよい。上手くやれば既存のchatエンドポイントを流用できると思う。